### PR TITLE
package.json: Set accurate `repository` value for this fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,7 @@
     }],
     "repository": {
         "type": "git",
-        "url": "http://github.com/ariya/esprima.git"
-    },
-    "bugs": {
-        "url": "http://issues.esprima.org"
+        "url": "http://github.com/jscs-dev/esprima-harmony.git"
     },
     "licenses": [{
         "type": "BSD",


### PR DESCRIPTION
Trying to backtrack this package from npm to a repo currently results in a dead end.
